### PR TITLE
refactor: use map instead of vector for used ways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tilemaker
 # protocol buffers generated headers
 include/osmformat.pb.h
 include/vector_tile.pb.h
+
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ include/osmformat.pb.h
 include/vector_tile.pb.h
 
 build/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,12 @@ tilemaker
 include/osmformat.pb.h
 include/vector_tile.pb.h
 
+# build directory
 build/
+
+# cmake files
+CMakeCache.txt
+CMakeFiles
+
+# macOS
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.tabSize": 4
+}

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -199,37 +199,40 @@ private:
 class UsedWays {
 
 private:
-	std::vector<bool> usedList;
+	std::map<WayID, bool> usedList;
 	mutable std::mutex mutex;
 
 public:
 	bool inited = false;
 
-	// Size the vector to a reasonable estimate, to avoid resizing on the fly
-	void reserve(bool compact, size_t numNodes) {
-		std::lock_guard<std::mutex> lock(mutex);
-		if (inited) return;
-		inited = true;
-		if (compact) {
-			// If we're running in compact mode, way count is roughly 1/9th of node count... say 1/8 to be safe
-			usedList.reserve(numNodes/8);
-		} else {
-			// Otherwise, we could have anything up to the current max node ID (approaching 2**30 in summer 2021)
-			// 2**31 is 0.25GB with a vector<bool>
-			usedList.reserve(pow(2,31));
-		}
-	}
+	// // Size the vector to a reasonable estimate, to avoid resizing on the fly
+	// void reserve(bool compact, size_t numNodes) {
+	// 	std::lock_guard<std::mutex> lock(mutex);
+	// 	if (inited) return;
+	// 	inited = true;
+	// 	if (compact) {
+	// 		// If we're running in compact mode, way count is roughly 1/9th of node count... say 1/8 to be safe
+	// 		usedList.reserve(numNodes/8);
+	// 	} else {
+	// 		// Otherwise, we could have anything up to the current max node ID (approaching 2**30 in summer 2021)
+	// 		// 2**31 is 0.25GB with a vector<bool>
+	// 		usedList.reserve(pow(2,31));
+	// 	}
+	// }
 	
 	// Mark a way as used
 	void insert(WayID wayid) {
 		std::lock_guard<std::mutex> lock(mutex);
-		if (wayid>usedList.size()) usedList.resize(wayid+256);
 		usedList[wayid] = true;
 	}
 	
 	// See if a way is used
 	bool at(WayID wayid) const {
-		return (wayid>usedList.size()) ? false : usedList[wayid];
+		if (usedList.find(wayid) != usedList.end()) {
+			return usedList.at(wayid);
+		} else {
+			return false;
+		}
 	}
 	
 	void clear() {
@@ -501,9 +504,9 @@ public:
 
 	void mark_way_used(WayID i) { used_ways.insert(i); }
 	bool way_is_used(WayID i) { return used_ways.at(i); }
-	void ensure_used_ways_inited() {
-		if (!used_ways.inited) used_ways.reserve(use_compact_nodes, nodes_size());
-	}
+	// void ensure_used_ways_inited() {
+	// 	if (!used_ways.inited) used_ways.reserve(use_compact_nodes, nodes_size());
+	// }
 	
 	using tag_map_t = boost::container::flat_map<std::string, std::string>;
 	void relation_contains_way(WayID relid, WayID wayid) { scanned_relations.relation_contains_way(relid,wayid); }

--- a/include/osm_store.h
+++ b/include/osm_store.h
@@ -205,21 +205,6 @@ private:
 public:
 	bool inited = false;
 
-	// // Size the vector to a reasonable estimate, to avoid resizing on the fly
-	// void reserve(bool compact, size_t numNodes) {
-	// 	std::lock_guard<std::mutex> lock(mutex);
-	// 	if (inited) return;
-	// 	inited = true;
-	// 	if (compact) {
-	// 		// If we're running in compact mode, way count is roughly 1/9th of node count... say 1/8 to be safe
-	// 		usedList.reserve(numNodes/8);
-	// 	} else {
-	// 		// Otherwise, we could have anything up to the current max node ID (approaching 2**30 in summer 2021)
-	// 		// 2**31 is 0.25GB with a vector<bool>
-	// 		usedList.reserve(pow(2,31));
-	// 	}
-	// }
-	
 	// Mark a way as used
 	void insert(WayID wayid) {
 		std::lock_guard<std::mutex> lock(mutex);
@@ -504,10 +489,7 @@ public:
 
 	void mark_way_used(WayID i) { used_ways.insert(i); }
 	bool way_is_used(WayID i) { return used_ways.at(i); }
-	// void ensure_used_ways_inited() {
-	// 	if (!used_ways.inited) used_ways.reserve(use_compact_nodes, nodes_size());
-	// }
-	
+
 	using tag_map_t = boost::container::flat_map<std::string, std::string>;
 	void relation_contains_way(WayID relid, WayID wayid) { scanned_relations.relation_contains_way(relid,wayid); }
 	void store_relation_tags(WayID relid, const tag_map_t &tags) { scanned_relations.store_relation_tags(relid,tags); }

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -249,7 +249,7 @@ bool PbfReader::ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::p
 		}
 
 		if(phase == ReadPhase::RelationScan || phase == ReadPhase::All) {
-			osmStore.ensure_used_ways_inited();
+			// osmStore.ensure_used_ways_inited();
 			bool done = ScanRelations(output, pg, pb);
 			if(done) { 
 				std::cout << "(Scanning for ways used in relations: " << (100*progress.first/progress.second) << "%)\r";
@@ -348,7 +348,7 @@ int PbfReader::ReadPbfFile(unordered_set<string> const &nodeKeys, unsigned int t
 				});
 			}
 		}
-	
+
 		pool.join();
 
 		if(phase == ReadPhase::Nodes) {

--- a/src/read_pbf.cpp
+++ b/src/read_pbf.cpp
@@ -249,7 +249,6 @@ bool PbfReader::ReadBlock(std::istream &infile, OsmLuaProcessing &output, std::p
 		}
 
 		if(phase == ReadPhase::RelationScan || phase == ReadPhase::All) {
-			// osmStore.ensure_used_ways_inited();
 			bool done = ScanRelations(output, pg, pb);
 			if(done) { 
 				std::cout << "(Scanning for ways used in relations: " << (100*progress.first/progress.second) << "%)\r";


### PR DESCRIPTION
- [x] Use `std::map` instead of `std::vector` for storing use way id's. Because tilemaker cannot allocate memory for `std::vector` (during vector resizing) due to large way id's. (https://stackoverflow.com/questions/13536501/how-to-resize-a-large-vector-safely-in-c)